### PR TITLE
Refactor Args out

### DIFF
--- a/Args.h
+++ b/Args.h
@@ -1,0 +1,48 @@
+// This file is part of TetWild, a software for generating tetrahedral meshes.
+// 
+// Copyright (C) 2018 Yixin Hu <yixin.hu@nyu.edu>
+// 
+// This Source Code Form is subject to the terms of the Mozilla Public License 
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can 
+// obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Created by Yixin Hu on 3/29/17.
+//
+
+#ifndef ARGS_H
+#define ARGS_H
+
+#include <string>
+
+namespace tetwild {
+
+struct Args{
+    std::string input;
+    std::string output = "";
+    std::string postfix = "_";
+    double i_ideal_edge_length = 20;
+    double i_epsilon = 1000;
+    int i_dd = -1;
+    int stage = 1;
+    double adaptive_scalar = 0.6;
+    double filter_energy = 10;
+    double delta_energy = 0.1;
+    int max_pass = 80;
+    int is_output_csv = true;
+    std::string csv_file = "";
+    std::string slz_file = "";
+
+    int mid_result = -1;
+    bool is_using_voxel = true;
+    bool is_laplacian = false;
+
+    int targeted_num_v = -1;
+    std::string bg_mesh = "";
+
+    bool is_quiet = false;
+    std::string output_mesh_format = "";
+};
+
+}
+
+#endif

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,7 @@ find_package(Eigen REQUIRED)
 SET(MAIN_FILE main.cpp)
 
 set(SOURCE_FILES
+        Args.h
 		BSPElements.h TetmeshElements.h
 		Preprocess.cpp Preprocess.h
 		DelaunayTetrahedralization.cpp DelaunayTetrahedralization.h
@@ -114,5 +115,5 @@ INSTALL(TARGETS lib_tetwild TetWild
     LIBRARY DESTINATION lib
     ARCHIVE DESTINATION lib
     RUNTIME DESTINATION bin)
-INSTALL(FILES tetwild.h
+INSTALL(FILES Args.h tetwild.h
     DESTINATION include)

--- a/heads.h
+++ b/heads.h
@@ -38,6 +38,7 @@
 
 #include "pymesh/MshSaver.h"
 #include "pymesh/MshLoader.h"
+#include "Args.h"
 
 using std::cerr;
 using std::cout;
@@ -115,33 +116,7 @@ extern std::string g_stat_file;
 extern std::string g_postfix;
 extern std::string g_output_file;
 
-struct Args{
-    std::string input;
-    std::string output = "";
-    std::string postfix = "_";
-    double i_ideal_edge_length = 20;
-    double i_epsilon = 1000;
-    int i_dd = -1;
-    int stage = 1;
-    double adaptive_scalar = 0.6;
-    double filter_energy = 10;
-    double delta_energy = 0.1;
-    int max_pass = 80;
-    int is_output_csv = true;
-    std::string csv_file = "";
-    std::string slz_file = "";
-
-    int mid_result = -1;
-    bool is_using_voxel = true;
-    bool is_laplacian = false;
-
-    int targeted_num_v = -1;
-    std::string bg_mesh = "";
-
-    bool is_quiet = false;
-    std::string output_mesh_format = "";
-};
-
+using Args = tetwild::Args;
 extern Args args;
 
 extern double g_eps;

--- a/tetwild.h
+++ b/tetwild.h
@@ -13,8 +13,11 @@
 
 #include <array>
 #include <vector>
+#include "Args.h"
 
 namespace tetwild {
+
+    extern Args parameters;
 
     void tetrahedralization(const std::vector<std::array<double, 3>>& V_in,
                             const std::vector<std::array<int, 3>>& F_in,


### PR DESCRIPTION
We cannot `#include "heads.h"` because it will bring in every `.h` files, which clusters the namespace and may cause unnecessary name collisions since many symbols are in global namespace.

Instead, let's minimize the codes that user need to `include` so tetwild can be used as a blackbox.