### PR TITLE
Make ISPC codepath thread-safe + improve distance queries.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,8 @@ add_library(libTetWild STATIC
 		src/tetwild/Common.h
 		src/tetwild/DelaunayTetrahedralization.cpp
 		src/tetwild/DelaunayTetrahedralization.h
+		src/tetwild/DistanceQuery.cpp
+		src/tetwild/DistanceQuery.h
 		src/tetwild/EdgeCollapser.cpp
 		src/tetwild/EdgeCollapser.h
 		src/tetwild/EdgeRemover.cpp
@@ -118,6 +120,8 @@ add_library(libTetWild STATIC
 		src/tetwild/tetwild.cpp
 		src/tetwild/VertexSmoother.cpp
 		src/tetwild/VertexSmoother.h
+		src/tetwild/geogram/mesh_AABB.cpp
+		src/tetwild/geogram/mesh_AABB.h
 )
 target_include_directories(libTetWild
 	PRIVATE

--- a/include/tetwild/tetwild.h
+++ b/include/tetwild/tetwild.h
@@ -17,7 +17,7 @@
 namespace tetwild {
 
 ///
-/// Robust tetrahedralization of an input triangle soup, with an envelop constraint.
+/// Robust tetrahedralization of an input triangle soup, with an envelope constraint.
 ///
 /// @param[in]  VI    { #VI x 3 input mesh vertices }
 /// @param[in]  FI    { #FI x 3 input mesh triangles }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -74,7 +74,8 @@ void gtet_new_slz(const Eigen::MatrixXd &VI, const Eigen::MatrixXi &FI, const st
                   const Args &args = Args())
 {
     State state(args, VI);
-    MeshRefinement MR(args, state);
+    GEO::Mesh sf, b;
+    MeshRefinement MR(sf, b, args, state);
     MR.deserialization(VI, FI, slz_file);
 
 //    MR.is_dealing_unrounded = true;

--- a/src/tetwild/DistanceQuery.h
+++ b/src/tetwild/DistanceQuery.h
@@ -1,0 +1,41 @@
+// This file is part of TetWild, a software for generating tetrahedral meshes.
+//
+// Copyright (C) 2018 Jeremie Dumas <jeremie.dumas@ens-lyon.org>
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License
+// v. 2.0. If a copy of the MPL was not distributed with this file, You can
+// obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Created by Jeremie Dumas on 09/04/18.
+//
+
+#pragma once
+
+#include <string>
+#include <geogram/mesh/mesh.h>
+#include <geogram/mesh/mesh_geometry.h>
+
+namespace tetwild {
+
+inline void get_point_facet_nearest_point(
+    const GEO::Mesh& M,
+    const GEO::vec3& p,
+    GEO::index_t f,
+    GEO::vec3& nearest_p,
+    double& squared_dist
+) {
+    using namespace GEO;
+    geo_debug_assert(M.facets.nb_vertices(f) == 3);
+    index_t c = M.facets.corners_begin(f);
+    const vec3& p1 = Geom::mesh_vertex(M, M.facet_corners.vertex(c));
+    ++c;
+    const vec3& p2 = Geom::mesh_vertex(M, M.facet_corners.vertex(c));
+    ++c;
+    const vec3& p3 = Geom::mesh_vertex(M, M.facet_corners.vertex(c));
+    double lambda1, lambda2, lambda3;  // barycentric coords, not used.
+    squared_dist = Geom::point_triangle_squared_distance(
+        p, p1, p2, p3, nearest_p, lambda1, lambda2, lambda3
+    );
+}
+
+} // namespace tetwild

--- a/src/tetwild/LocalOperations.h
+++ b/src/tetwild/LocalOperations.h
@@ -14,7 +14,7 @@
 
 #include <tetwild/ForwardDecls.h>
 #include <tetwild/TetmeshElements.h>
-#include <geogram/mesh/mesh_AABB.h>
+#include <tetwild/geogram/mesh_AABB.h>
 #include <igl/grad.h>
 #include <igl/Timer.h>
 
@@ -44,8 +44,9 @@ public:
 
     int energy_type;
 
-    GEO::MeshFacetsAABB& geo_sf_tree;
-    GEO::MeshFacetsAABB& geo_b_tree;
+    const GEO::Mesh &geo_sf_mesh;
+    const GEO::MeshFacetsAABBWithEps& geo_sf_tree;
+    const GEO::MeshFacetsAABBWithEps& geo_b_tree;
 
     int counter=0;
     int suc_counter=0;
@@ -54,10 +55,12 @@ public:
 
     LocalOperations(std::vector<TetVertex>& t_vs, std::vector<std::array<int, 4>>& ts, std::vector<std::array<int, 4>>& is_sf_fs,
                     std::vector<bool>& v_is_rm, std::vector<bool>& t_is_rm, std::vector<TetQuality>& tet_qs,
-                    int e_type, GEO::MeshFacetsAABB& geo_tree, GEO::MeshFacetsAABB& b_t,
+                    int e_type, const GEO::Mesh &geo_mesh, const GEO::MeshFacetsAABBWithEps& geo_tree, const GEO::MeshFacetsAABBWithEps& b_t,
                     const Args &ar, State &st) :
         tet_vertices(t_vs), tets(ts), is_surface_fs(is_sf_fs), v_is_removed(v_is_rm), t_is_removed(t_is_rm),
-        tet_qualities(tet_qs), energy_type(e_type), geo_sf_tree(geo_tree), geo_b_tree(b_t), args(ar), state(st)
+        tet_qualities(tet_qs), energy_type(e_type),
+        geo_sf_mesh(geo_mesh), geo_sf_tree(geo_tree), geo_b_tree(b_t),
+        args(ar), state(st)
     { }
 
     void check();
@@ -103,9 +106,9 @@ public:
     bool isIsolated(int v_id);
     bool isBoundaryPoint(int v_id);
 
-    double comformalAMIPSEnergy_new(const std::vector<double>& T);
-    void comformalAMIPSJacobian_new(const std::vector<double>& T, double *result_0);
-    void comformalAMIPSHessian_new(const std::vector<double>& T, double *result_0);
+    static double comformalAMIPSEnergy_new(const double * T);
+    static void comformalAMIPSJacobian_new(const double * T, double *result_0);
+    static void comformalAMIPSHessian_new(const double * T, double *result_0);
 
     igl::Timer igl_timer0;
     int id_sampling=0;

--- a/src/tetwild/MeshRefinement.cpp
+++ b/src/tetwild/MeshRefinement.cpp
@@ -19,10 +19,12 @@
 #include <tetwild/EdgeRemover.h>
 #include <tetwild/VertexSmoother.h>
 #include <tetwild/DisableWarnings.h>
+#include <tetwild/geogram/mesh_AABB.h>
 #include <CGAL/centroid.h>
 #include <tetwild/EnableWarnings.h>
 #include <pymesh/MshLoader.h>
 #include <pymesh/MshSaver.h>
+#include <geogram/mesh/mesh_AABB.h>
 #include <geogram/points/kd_tree.h>
 #include <igl/winding_number.h>
 
@@ -43,9 +45,9 @@ void MeshRefinement::prepareData(bool is_init) {
 
     GEO::Mesh simple_mesh;
     getSimpleMesh(simple_mesh);
-    GEO::MeshFacetsAABB simple_tree(simple_mesh);
+    GEO::MeshFacetsAABBWithEps simple_tree(simple_mesh);
     LocalOperations localOperation(tet_vertices, tets, is_surface_fs, v_is_removed, t_is_removed, tet_qualities,
-                                   state.ENERGY_AMIPS, simple_tree, simple_tree, args, state);
+                                   state.ENERGY_AMIPS, simple_mesh, simple_tree, simple_tree, args, state);
     localOperation.calTetQualities(tets, tet_qualities, true);//cal all measure
     double tmp_time = igl_timer.getElapsedTime();
     logger().debug("{}s", tmp_time);
@@ -204,11 +206,11 @@ int MeshRefinement::doOperationLoops(EdgeSplitter& splitter, EdgeCollapser& coll
 }
 
 void MeshRefinement::refine(int energy_type, const std::array<bool, 4>& ops, bool is_pre, bool is_post, int scalar_update) {
-    GEO::MeshFacetsAABB geo_sf_tree(geo_sf_mesh);
+    GEO::MeshFacetsAABBWithEps geo_sf_tree(geo_sf_mesh);
     if (geo_b_mesh.vertices.nb() == 0) {
         getSimpleMesh(geo_b_mesh);//for constructing aabb tree, the mesh cannot be empty
     }
-    GEO::MeshFacetsAABB geo_b_tree(geo_b_mesh);
+    GEO::MeshFacetsAABBWithEps geo_b_tree(geo_b_mesh);
 
     if (is_dealing_unrounded)
         min_adaptive_scale = state.eps / state.initial_edge_len * 0.5; //min to eps/2
@@ -217,7 +219,7 @@ void MeshRefinement::refine(int energy_type, const std::array<bool, 4>& ops, boo
         min_adaptive_scale = (state.bbox_diag / 1000) / state.initial_edge_len; // set min_edge_length to diag / 1000 would be better
 
     LocalOperations localOperation(tet_vertices, tets, is_surface_fs, v_is_removed, t_is_removed, tet_qualities,
-                                   energy_type, geo_sf_tree, geo_b_tree, args, state);
+                                   energy_type, geo_sf_mesh, geo_sf_tree, geo_b_tree, args, state);
     EdgeSplitter splitter(localOperation, state.initial_edge_len * (4.0 / 3.0) * state.initial_edge_len * (4.0 / 3.0));
     EdgeCollapser collapser(localOperation, state.initial_edge_len * (4.0 / 5.0) * state.initial_edge_len * (4.0 / 5.0));
     EdgeRemover edge_remover(localOperation, state.initial_edge_len * (4.0 / 3.0) * state.initial_edge_len * (4.0 / 3.0));

--- a/src/tetwild/MeshRefinement.h
+++ b/src/tetwild/MeshRefinement.h
@@ -14,7 +14,6 @@
 
 #include <tetwild/ForwardDecls.h>
 #include <tetwild/TetmeshElements.h>
-#include <geogram/mesh/mesh_AABB.h>
 #include <geogram/mesh/mesh.h>
 #include <igl/Timer.h>
 

--- a/src/tetwild/MeshRefinement.h
+++ b/src/tetwild/MeshRefinement.h
@@ -23,6 +23,10 @@ class MeshRefinement {
 public:
     const Args &args;
     State &state;
+
+    GEO::Mesh &geo_sf_mesh;
+    GEO::Mesh &geo_b_mesh;
+
     //init
     std::vector<TetVertex> tet_vertices;
     std::vector<std::array<int, 4>> tets;
@@ -32,14 +36,13 @@ public:
     std::vector<TetQuality> tet_qualities;
     std::vector<std::array<int, 4>> is_surface_fs;
 
-    GEO::Mesh geo_sf_mesh;
-    GEO::Mesh geo_b_mesh;
-
     igl::Timer igl_timer;
 
     int old_pass = 0;
 
-    MeshRefinement(const Args &ar, State &st) : args(ar), state(st) { }
+    MeshRefinement(GEO::Mesh & sf_mesh, GEO::Mesh & b_mesh, const Args &ar, State &st)
+        : geo_sf_mesh(sf_mesh), geo_b_mesh(b_mesh), args(ar), state(st)
+    { }
 
     void prepareData(bool is_init=true);
     void round();

--- a/src/tetwild/Preprocess.h
+++ b/src/tetwild/Preprocess.h
@@ -14,8 +14,8 @@
 
 #include <tetwild/ForwardDecls.h>
 #include <tetwild/CGALTypes.h>
+#include <tetwild/geogram/mesh_AABB.h>
 #include <geogram/mesh/mesh.h>
-#include <geogram/mesh/mesh_AABB.h>
 #include <Eigen/Dense>
 #include <unordered_set>
 #include <queue>
@@ -56,14 +56,14 @@ public:
 
     bool init(const Eigen::MatrixXd& V_tmp, const Eigen::MatrixXi& F_tmp, GEO::Mesh& geo_b_mesh, GEO::Mesh& geo_sf_mesh, const Args &args);
 
-    void getBoudnaryMesh(GEO::Mesh& b_mesh);
+    void getBoundaryMesh(GEO::Mesh& b_mesh);
     void process(GEO::Mesh& geo_sf_mesh, std::vector<Point_3>& m_vertices, std::vector<std::array<int, 3>>& m_faces, const Args &args);
 
-    void simplify(GEO::MeshFacetsAABB& face_aabb_tree);
-    void postProcess(GEO::MeshFacetsAABB& face_aabb_tree);
-    bool removeAnEdge(int v1_id, int v2_id, GEO::MeshFacetsAABB& face_aabb_tree);
+    void simplify(const GEO::Mesh &geo_mesh, const GEO::MeshFacetsAABBWithEps& face_aabb_tree);
+    void postProcess(const GEO::Mesh &geo_mesh, const GEO::MeshFacetsAABBWithEps& face_aabb_tree);
+    bool removeAnEdge(int v1_id, int v2_id, const GEO::Mesh &geo_mesh, const GEO::MeshFacetsAABBWithEps& face_aabb_tree);
 
-    void swap(GEO::MeshFacetsAABB& face_aabb_tree);
+    void swap(const GEO::Mesh &geo_mesh, const GEO::MeshFacetsAABBWithEps& face_aabb_tree);
     double getCosAngle(int v_id, int v1_id, int v2_id);
 
     double getEdgeLength(const std::array<int, 2>& v_ids);
@@ -72,8 +72,8 @@ public:
     bool isEdgeValid(const std::array<int, 2>& v_ids, double old_weight);
     bool isEdgeValid(const std::array<int, 2>& v_ids);
     bool isOneRingClean(int v_id);
-    bool isOutEnvelop(const std::unordered_set<int>& new_f_ids, GEO::MeshFacetsAABB& face_aabb_tree);
-    bool isPointOutEnvelop(int v_id, GEO::MeshFacetsAABB& face_aabb_tree);
+    bool isOutEnvelop(const std::unordered_set<int>& new_f_ids, const GEO::Mesh &geo_mesh, const GEO::MeshFacetsAABBWithEps& face_aabb_tree);
+    bool isPointOutEnvelop(int v_id, const GEO::MeshFacetsAABBWithEps& face_aabb_tree);
     bool isEuclideanValid(int v1_id, int v2_id);
     //when call this function, the coordinate of v1 has already been changed
 
@@ -82,7 +82,7 @@ public:
     std::vector<int> inf_e_tss;
     std::vector<int> f_tss;
 
-    void outputSurfaceColormap(GEO::MeshFacetsAABB& geo_face_tree, GEO::Mesh& geo_sf_mesh);
+    void outputSurfaceColormap(const GEO::MeshFacetsAABBWithEps& geo_face_tree, const GEO::Mesh& geo_sf_mesh);
 };
 
 } // namespace tetwild

--- a/src/tetwild/geogram/mesh_AABB.cpp
+++ b/src/tetwild/geogram/mesh_AABB.cpp
@@ -1,0 +1,576 @@
+/*
+ *  Copyright (c) 2012-2014, Bruno Levy
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *  this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  * Neither the name of the ALICE Project-Team nor the names of its
+ *  contributors may be used to endorse or promote products derived from this
+ *  software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ *  If you modify this software, you should include a notice giving the
+ *  name of the person performing the modification, the date of modification,
+ *  and the reason for such modification.
+ *
+ *  Contact: Bruno Levy
+ *
+ *     Bruno.Levy@inria.fr
+ *     http://www.loria.fr/~levy
+ *
+ *     ALICE Project
+ *     LORIA, INRIA Lorraine,
+ *     Campus Scientifique, BP 239
+ *     54506 VANDOEUVRE LES NANCY CEDEX
+ *     FRANCE
+ *
+ */
+
+#include <tetwild/geogram/mesh_AABB.h>
+#include <geogram/mesh/mesh_reorder.h>
+#include <geogram/mesh/mesh_geometry.h>
+#include <geogram/mesh/mesh_repair.h>
+#include <geogram/numerics/predicates.h>
+#include <geogram/basic/geometry_nd.h>
+
+namespace {
+
+    using namespace GEO;
+
+    /**
+     * \brief Computes the axis-aligned bounding box of a mesh facet.
+     * \param[in] M the mesh
+     * \param[out] B the bounding box of the facet
+     * \param[in] f the index of the facet in mesh \p M
+     */
+    void get_facet_bbox(
+        const Mesh& M, Box& B, index_t f
+    ) {
+        index_t c = M.facets.corners_begin(f);
+        const double* p = M.vertices.point_ptr(M.facet_corners.vertex(c));
+        for(coord_index_t coord = 0; coord < 3; ++coord) {
+            B.xyz_min[coord] = p[coord];
+            B.xyz_max[coord] = p[coord];
+        }
+        for(++c; c < M.facets.corners_end(f); ++c) {
+            p = M.vertices.point_ptr(M.facet_corners.vertex(c));
+            for(coord_index_t coord = 0; coord < 3; ++coord) {
+                B.xyz_min[coord] = std::min(B.xyz_min[coord], p[coord]);
+                B.xyz_max[coord] = std::max(B.xyz_max[coord], p[coord]);
+            }
+        }
+    }
+
+    /**
+     * \brief Computes the maximum node index in a subtree
+     * \param[in] node_index node index of the root of the subtree
+     * \param[in] b first facet index in the subtree
+     * \param[in] e one position past the last facet index in the subtree
+     * \return the maximum node index in the subtree rooted at \p node_index
+     */
+    index_t max_node_index(index_t node_index, index_t b, index_t e) {
+        geo_debug_assert(e > b);
+        if(b + 1 == e) {
+            return node_index;
+        }
+        index_t m = b + (e - b) / 2;
+        index_t childl = 2 * node_index;
+        index_t childr = 2 * node_index + 1;
+        return std::max(
+            max_node_index(childl, b, m),
+            max_node_index(childr, m, e)
+        );
+    }
+
+    /**
+     * \brief Computes the hierarchy of bounding boxes recursively.
+     * \details This function is generic and can be used to compute
+     *  a bbox hierarchy of arbitrary elements.
+     * \param[in] M the mesh
+     * \param[in] bboxes the array of bounding boxes
+     * \param[in] node_index the index of the root of the subtree
+     * \param[in] b first element index in the subtree
+     * \param[in] e one position past the last element index in the subtree
+     * \param[in] get_bbox a function that computes the bbox of an element
+     * \tparam GET_BBOX a function (or a functor) with the following arguments:
+     *  - mesh: a const reference to the mesh
+     *  - box: a reference where the computed bounding box of the element
+     *   will be stored
+     *  - element: the index of the element
+     */
+    template <class GET_BBOX>
+    void init_bboxes_recursive(
+        const Mesh& M, vector<Box>& bboxes,
+        index_t node_index,
+        index_t b, index_t e,
+        const GET_BBOX& get_bbox
+    ) {
+        geo_debug_assert(node_index < bboxes.size());
+        geo_debug_assert(b != e);
+        if(b + 1 == e) {
+            get_bbox(M, bboxes[node_index], b);
+            return;
+        }
+        index_t m = b + (e - b) / 2;
+        index_t childl = 2 * node_index;
+        index_t childr = 2 * node_index + 1;
+        geo_debug_assert(childl < bboxes.size());
+        geo_debug_assert(childr < bboxes.size());
+        init_bboxes_recursive(M, bboxes, childl, b, m, get_bbox);
+        init_bboxes_recursive(M, bboxes, childr, m, e, get_bbox);
+        geo_debug_assert(childl < bboxes.size());
+        geo_debug_assert(childr < bboxes.size());
+        bbox_union(bboxes[node_index], bboxes[childl], bboxes[childr]);
+    }
+
+    /**
+     * \brief Finds the nearest point in a mesh facet from a query point.
+     * \param[in] M the mesh
+     * \param[in] p the query point
+     * \param[in] f index of the facet in \p M
+     * \param[out] nearest_p the point of facet \p f nearest to \p p
+     * \param[out] squared_dist the squared distance between
+     *  \p p and \p nearest_p
+     * \pre the mesh \p M is triangulated
+     */
+    void get_point_facet_nearest_point(
+        const Mesh& M,
+        const vec3& p,
+        index_t f,
+        vec3& nearest_p,
+        double& squared_dist
+    ) {
+        geo_debug_assert(M.facets.nb_vertices(f) == 3);
+        index_t c = M.facets.corners_begin(f);
+        const vec3& p1 = Geom::mesh_vertex(M, M.facet_corners.vertex(c));
+        ++c;
+        const vec3& p2 = Geom::mesh_vertex(M, M.facet_corners.vertex(c));
+        ++c;
+        const vec3& p3 = Geom::mesh_vertex(M, M.facet_corners.vertex(c));
+        double lambda1, lambda2, lambda3;  // barycentric coords, not used.
+        squared_dist = Geom::point_triangle_squared_distance(
+            p, p1, p2, p3, nearest_p, lambda1, lambda2, lambda3
+        );
+    }
+
+    /**
+     * \brief Computes the squared distance between a point and a Box.
+     * \param[in] p the point
+     * \param[in] B the box
+     * \return the squared distance between \p p and \p B
+     * \pre p is inside B
+     */
+    double inner_point_box_squared_distance(
+        const vec3& p,
+        const Box& B
+    ) {
+        geo_debug_assert(B.contains(p));
+        double result = geo_sqr(p[0] - B.xyz_min[0]);
+        result = std::min(result, geo_sqr(p[0] - B.xyz_max[0]));
+        for(coord_index_t c = 1; c < 3; ++c) {
+            result = std::min(result, geo_sqr(p[c] - B.xyz_min[c]));
+            result = std::min(result, geo_sqr(p[c] - B.xyz_max[c]));
+        }
+        return result;
+    }
+
+    /**
+     * \brief Computes the squared distance between a point and a Box
+     *  with negative sign if the point is inside the Box.
+     * \param[in] p the point
+     * \param[in] B the box
+     * \return the signed squared distance between \p p and \p B
+     */
+    double point_box_signed_squared_distance(
+        const vec3& p,
+        const Box& B
+    ) {
+        bool inside = true;
+        double result = 0.0;
+        for(coord_index_t c = 0; c < 3; c++) {
+            if(p[c] < B.xyz_min[c]) {
+                inside = false;
+                result += geo_sqr(p[c] - B.xyz_min[c]);
+            } else if(p[c] > B.xyz_max[c]) {
+                inside = false;
+                result += geo_sqr(p[c] - B.xyz_max[c]);
+            }
+        }
+        if(inside) {
+            result = -inner_point_box_squared_distance(p, B);
+        }
+        return result;
+    }
+
+    /**
+     * \brief Computes the squared distance between a point and the
+     *  center of a box.
+     * \param[in] p the point
+     * \param[in] B the box
+     * \return the squared distance between \p p and the center of \p B
+     */
+    double point_box_center_squared_distance(
+        const vec3& p, const Box& B
+    ) {
+        double result = 0.0;
+        for(coord_index_t c = 0; c < 3; ++c) {
+            double d = p[c] - 0.5 * (B.xyz_min[c] + B.xyz_max[c]);
+            result += geo_sqr(d);
+        }
+        return result;
+    }
+
+    /**
+     * \brief Tests whether a segment intersects a triangle.
+     * \param[in] q1 , q2 the two extremities of the segment.
+     * \param[in] p1 , p2 , p3 the three vertices of the triangle.
+     * \retval true if [q1,q2] has an intersection with (p1, p2, p3).
+     * \retval false otherwise.
+     */
+    bool segment_triangle_intersection(
+        const vec3& q1, const vec3& q2,
+        const vec3& p1, const vec3& p2, const vec3& p3
+    ) {
+
+        //   If the segment does not straddle the supporting plane of the
+        // triangle, then there is no intersection.
+        vec3 N = cross(p2-p1, p3-p1);
+        if(dot(q1-p1,N)*dot(q2-p1,N) > 0.0) {
+            return false;
+        }
+
+        //  The three tetrahedra formed by the segment and the three edges
+        // of the triangle should have the same sign, else there is no
+        // intersection.
+        int s1 = geo_sgn(Geom::tetra_signed_volume(q1,q2,p1,p2));
+        int s2 = geo_sgn(Geom::tetra_signed_volume(q1,q2,p2,p3));
+        if(s1 != s2) {
+            return false;
+        }
+        int s3 = geo_sgn(Geom::tetra_signed_volume(q1,q2,p3,p1));
+        return (s2 == s3);
+    }
+
+    /**
+     * \brief Tests whether there is an intersection between a segment
+     *  and a mesh facet.
+     * \param[in] q1 , q2 the extremities of the segment
+     * \param[in] M the mesh
+     * \param[in] f the facet
+     */
+    bool segment_mesh_facet_intersection(
+        const vec3& q1, const vec3& q2,
+        const Mesh& M,
+        index_t f
+    ) {
+        geo_debug_assert(M.facets.nb_vertices(f) == 3);
+        index_t c = M.facets.corners_begin(f);
+        const vec3& p1 = Geom::mesh_vertex(M, M.facet_corners.vertex(c));
+        ++c;
+        const vec3& p2 = Geom::mesh_vertex(M, M.facet_corners.vertex(c));
+        ++c;
+        const vec3& p3 = Geom::mesh_vertex(M, M.facet_corners.vertex(c));
+        return segment_triangle_intersection(q1, q2, p1, p2, p3);
+    }
+
+    /**
+     * \brief Tests whether a segment intersects a box.
+     * \param[in] q1 , q2 the two extremities of the segment.
+     * \param[in] box the box.
+     * \retval true if [q1,q2] intersects the box.
+     * \retval false otherwise.
+     */
+    bool segment_box_intersection(
+        const vec3& q1, const vec3& q2, const Box& box
+    ) {
+        // Ref: https://www.gamedev.net/forums/topic/338987-aabb---line-segment-intersection-test/
+        vec3 d(
+            0.5*(q2.x - q1.x),
+            0.5*(q2.y - q1.y),
+            0.5*(q2.z - q1.z)
+        );
+
+        vec3 e(
+            0.5*(box.xyz_max[0] - box.xyz_min[0]),
+            0.5*(box.xyz_max[1] - box.xyz_min[1]),
+            0.5*(box.xyz_max[2] - box.xyz_min[2])
+        );
+
+        vec3 c(
+            q1.x + d.x - 0.5*(box.xyz_min[0] + box.xyz_max[0]),
+            q1.y + d.y - 0.5*(box.xyz_min[1] + box.xyz_max[1]),
+            q1.z + d.z - 0.5*(box.xyz_min[2] + box.xyz_max[2])
+        );
+
+        vec3 ad(fabs(d.x), fabs(d.y), fabs(d.z));
+
+        if (fabs(c[0]) > e[0] + ad[0]) {
+            return false;
+        }
+
+        if (fabs(c[1]) > e[1] + ad[1]) {
+            return false;
+        }
+
+        if (fabs(c[2]) > e[2] + ad[2]) {
+            return false;
+        }
+
+        if (fabs(d[1] * c[2] - d[2] * c[1]) > e[1] * ad[2] + e[2] * ad[1]) {
+            return false;
+        }
+
+        if (fabs(d[2] * c[0] - d[0] * c[2]) > e[2] * ad[0] + e[0] * ad[2]) {
+            return false;
+        }
+
+        if (fabs(d[0] * c[1] - d[1] * c[0]) > e[0] * ad[1] + e[1] * ad[0]) {
+            return false;
+        }
+
+        return true;
+    }
+}
+
+/****************************************************************************/
+
+namespace GEO {
+
+    MeshFacetsAABBWithEps::MeshFacetsAABBWithEps(
+        Mesh& M, bool reorder
+    ) :
+        mesh_(M) {
+        if(!M.facets.are_simplices()) {
+            mesh_repair(
+                M,
+                MeshRepairMode(
+                    MESH_REPAIR_TRIANGULATE | MESH_REPAIR_QUIET
+                 )
+            );
+        }
+        if(reorder) {
+            mesh_reorder(mesh_, MESH_ORDER_MORTON);
+        }
+        bboxes_.resize(
+            max_node_index(
+                1, 0, mesh_.facets.nb()
+            ) + 1 // <-- this is because size == max_index + 1 !!!
+        );
+        init_bboxes_recursive(
+            mesh_, bboxes_, 1, 0, mesh_.facets.nb(), get_facet_bbox
+        );
+    }
+
+    void MeshFacetsAABBWithEps::get_nearest_facet_hint(
+        const vec3& p,
+        index_t& nearest_f, vec3& nearest_point, double& sq_dist
+    ) const {
+
+        // Find a good initial value for nearest_f by traversing
+        // the boxes and selecting the child such that the center
+        // of its bounding box is nearer to the query point.
+        // For a large mesh (20M facets) this gains up to 10%
+        // performance as compared to picking nearest_f randomly.
+        index_t b = 0;
+        index_t e = mesh_.facets.nb();
+        index_t n = 1;
+        while(e != b + 1) {
+            index_t m = b + (e - b) / 2;
+            index_t childl = 2 * n;
+            index_t childr = 2 * n + 1;
+            if(
+                point_box_center_squared_distance(p, bboxes_[childl]) <
+                point_box_center_squared_distance(p, bboxes_[childr])
+            ) {
+                e = m;
+                n = childl;
+            } else {
+                b = m;
+                n = childr;
+            }
+        }
+        nearest_f = b;
+
+        index_t v = mesh_.facet_corners.vertex(
+            mesh_.facets.corners_begin(nearest_f)
+        );
+        nearest_point = Geom::mesh_vertex(mesh_, v);
+        sq_dist = Geom::distance2(p, nearest_point);
+    }
+
+    void MeshFacetsAABBWithEps::nearest_facet_recursive(
+        const vec3& p,
+        index_t& nearest_f, vec3& nearest_point, double& sq_dist,
+        index_t n, index_t b, index_t e
+    ) const {
+        geo_debug_assert(e > b);
+
+        // If node is a leaf: compute point-facet distance
+        // and replace current if nearer
+        if(b + 1 == e) {
+            vec3 cur_nearest_point;
+            double cur_sq_dist;
+            get_point_facet_nearest_point(
+                mesh_, p, b, cur_nearest_point, cur_sq_dist
+            );
+            if(cur_sq_dist < sq_dist) {
+                nearest_f = b;
+                nearest_point = cur_nearest_point;
+                sq_dist = cur_sq_dist;
+            }
+            return;
+        }
+        index_t m = b + (e - b) / 2;
+        index_t childl = 2 * n;
+        index_t childr = 2 * n + 1;
+
+        double dl = point_box_signed_squared_distance(p, bboxes_[childl]);
+        double dr = point_box_signed_squared_distance(p, bboxes_[childr]);
+
+        // Traverse the "nearest" child first, so that it has more chances
+        // to prune the traversal of the other child.
+        if(dl < dr) {
+            if(dl < sq_dist) {
+                nearest_facet_recursive(
+                    p,
+                    nearest_f, nearest_point, sq_dist,
+                    childl, b, m
+                );
+            }
+            if(dr < sq_dist) {
+                nearest_facet_recursive(
+                    p,
+                    nearest_f, nearest_point, sq_dist,
+                    childr, m, e
+                );
+            }
+        } else {
+            if(dr < sq_dist) {
+                nearest_facet_recursive(
+                    p,
+                    nearest_f, nearest_point, sq_dist,
+                    childr, m, e
+                );
+            }
+            if(dl < sq_dist) {
+                nearest_facet_recursive(
+                    p,
+                    nearest_f, nearest_point, sq_dist,
+                    childl, b, m
+                );
+            }
+        }
+    }
+
+    void MeshFacetsAABBWithEps::facet_in_envelope_recursive(
+        const vec3& p, double sq_epsilon,
+        index_t& nearest_f, vec3& nearest_point, double& sq_dist,
+        index_t n, index_t b, index_t e
+    ) const {
+        geo_debug_assert(e > b);
+
+        if (sq_dist <= sq_epsilon) {
+            return;
+        }
+
+        // If node is a leaf: compute point-facet distance
+        // and replace current if nearer
+        if(b + 1 == e) {
+            vec3 cur_nearest_point;
+            double cur_sq_dist;
+            get_point_facet_nearest_point(
+                mesh_, p, b, cur_nearest_point, cur_sq_dist
+            );
+            if(cur_sq_dist < sq_dist) {
+                nearest_f = b;
+                nearest_point = cur_nearest_point;
+                sq_dist = cur_sq_dist;
+            }
+            return;
+        }
+        index_t m = b + (e - b) / 2;
+        index_t childl = 2 * n;
+        index_t childr = 2 * n + 1;
+
+        double dl = point_box_signed_squared_distance(p, bboxes_[childl]);
+        double dr = point_box_signed_squared_distance(p, bboxes_[childr]);
+
+        // Traverse the "nearest" child first, so that it has more chances
+        // to prune the traversal of the other child.
+        if(dl < dr) {
+            if(dl < sq_dist && dl <= sq_epsilon) {
+                facet_in_envelope_recursive(
+                    p, sq_epsilon,
+                    nearest_f, nearest_point, sq_dist,
+                    childl, b, m
+                );
+            }
+            if(dr < sq_dist && dr <= sq_epsilon) {
+                facet_in_envelope_recursive(
+                    p, sq_epsilon,
+                    nearest_f, nearest_point, sq_dist,
+                    childr, m, e
+                );
+            }
+        } else {
+            if(dr < sq_dist && dr <= sq_epsilon) {
+                facet_in_envelope_recursive(
+                    p, sq_epsilon,
+                    nearest_f, nearest_point, sq_dist,
+                    childr, m, e
+                );
+            }
+            if(dl < sq_dist && dl <= sq_epsilon) {
+                facet_in_envelope_recursive(
+                    p, sq_epsilon,
+                    nearest_f, nearest_point, sq_dist,
+                    childl, b, m
+                );
+            }
+        }
+    }
+
+
+    bool MeshFacetsAABBWithEps::segment_intersection(const vec3& q1, const vec3& q2) const {
+        return segment_intersection_recursive(q1, q2, 1, 0, mesh_.facets.nb());
+    }
+
+    bool MeshFacetsAABBWithEps::segment_intersection_recursive(
+        const vec3& q1, const vec3& q2, index_t n, index_t b, index_t e
+    ) const {
+        if(!segment_box_intersection(q1, q2, bboxes_[n])) {
+            return false;
+        }
+        if(b + 1 == e) {
+            return segment_mesh_facet_intersection(q1, q2, mesh_, b);
+        }
+        index_t m = b + (e - b) / 2;
+        index_t childl = 2 * n;
+        index_t childr = 2 * n + 1;
+        return (
+            segment_intersection_recursive(q1, q2, childl, b, m) ||
+            segment_intersection_recursive(q1, q2, childr, m, e)
+        );
+    }
+
+/****************************************************************************/
+
+}
+

--- a/src/tetwild/geogram/mesh_AABB.h
+++ b/src/tetwild/geogram/mesh_AABB.h
@@ -1,0 +1,423 @@
+/*
+ *  Copyright (c) 2012-2014, Bruno Levy
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *  this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ *  * Neither the name of the ALICE Project-Team nor the names of its
+ *  contributors may be used to endorse or promote products derived from this
+ *  software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ *  If you modify this software, you should include a notice giving the
+ *  name of the person performing the modification, the date of modification,
+ *  and the reason for such modification.
+ *
+ *  Contact: Bruno Levy
+ *
+ *     Bruno.Levy@inria.fr
+ *     http://www.loria.fr/~levy
+ *
+ *     ALICE Project
+ *     LORIA, INRIA Lorraine,
+ *     Campus Scientifique, BP 239
+ *     54506 VANDOEUVRE LES NANCY CEDEX
+ *     FRANCE
+ *
+ */
+
+#pragma once
+/**
+ * \file mesh_AABB.h
+ * \brief Axis Aligned Bounding Box trees for accelerating
+ *  geometric queries that operate on a Mesh.
+ */
+
+#include <geogram/basic/common.h>
+#include <geogram/mesh/mesh.h>
+#include <geogram/basic/geometry.h>
+
+namespace GEO {
+
+    /**
+     * \brief Axis Aligned Bounding Box tree of mesh facets.
+     * \details Used to quickly compute facet intersection and
+     *  to locate the nearest facet from 3d query points.
+     */
+    class GEOGRAM_API MeshFacetsAABBWithEps {
+    public:
+        /**
+         * \brief Creates the Axis Aligned Bounding Boxes tree.
+         * \param[in] M the input mesh. It can be modified,
+         *  and will be triangulated (if
+         *  not already a triangular mesh). The facets are
+         *  re-ordered (using Morton's order, see mesh_reorder()).
+         * \param[in] reorder if not set, Morton re-ordering is
+         *  skipped (but it means that mesh_reorder() was previously
+         *  called else the algorithm will be pretty unefficient).
+         * \pre M.facets.are_simplices()
+         */
+        MeshFacetsAABBWithEps(Mesh& M, bool reorder = true);
+
+        /**
+         * \brief Computes all the pairs of intersecting facets.
+         * \param[in] action ACTION::operator(index_t,index_t) is
+         *  invoked of all pairs of facets that have overlapping
+         *  bounding boxes. triangles_intersection() needs to be
+         *  called to detect the actual intersections.
+         * \tparam ACTION user action class, that needs to define
+         * operator(index_t,index_t), where the two indices are
+         * the indices each pair of triangles that have intersecting
+         * bounding boxes.
+         */
+        template <class ACTION>
+        void compute_facet_bbox_intersections(
+            ACTION& action
+        ) const {
+            intersect_recursive(
+                action,
+                1, 0, mesh_.facets.nb(),
+                1, 0, mesh_.facets.nb()
+            );
+        }
+
+
+        /**
+         * \brief Computes all the intersections between a given
+         *  box and the bounding boxes of all the facets.
+         * \param[in] action ACTION::operator(index_t) is
+         *  invoked for all facets that have a bounding
+         *  box that intersects \p box_in.
+         * \tparam ACTION user action class, that needs to define
+         * operator(index_t), where the parameter is the index
+         * of the triangle that has its bounding box intersecting
+         * \p box_in.
+         */
+        template< class ACTION >
+        void compute_bbox_facet_bbox_intersections(
+            const Box& box_in,
+            ACTION& action
+        ) const {
+            bbox_intersect_recursive(
+                action, box_in, 1, 0, mesh_.facets.nb()
+            );
+        }
+
+        /**
+         * \brief Finds the nearest facet from an arbitrary 3d query point.
+         * \param[in] p query point
+         * \param[out] nearest_point nearest point on the surface
+         * \param[out] sq_dist squared distance between p and the surface.
+         * \return the index of the facet nearest to point p.
+         */
+        index_t nearest_facet(
+            const vec3& p, vec3& nearest_point, double& sq_dist
+        ) const {
+            index_t nearest_facet;
+            get_nearest_facet_hint(p, nearest_facet, nearest_point, sq_dist);
+            nearest_facet_recursive(
+                p,
+                nearest_facet, nearest_point, sq_dist,
+                1, 0, mesh_.facets.nb()
+            );
+            return nearest_facet;
+        }
+
+        /**
+         * \brief Computes the nearest point and nearest facet from
+         * a query point, using user-specified hint.
+         *
+         * \details The hint is specified as reasonable initial values of
+         * (nearest_facet, nearest_point, sq_dist). If multiple queries
+         * are done on a set of points that has spatial locality,
+         * the hint can be the result of the previous call.
+         *
+         * \param[in] p query point
+         * \param[in,out] nearest_facet the nearest facet so far,
+         *   or NO_FACET if not known yet
+         * \param[in,out] nearest_point a point in nearest_facet
+         * \param[in,out] sq_dist squared distance between p and
+         *    nearest_point
+         * \note On entry, \p sq_dist needs to be equal to the squared
+         *   distance between \p p and \p nearest_point (it is easy to
+         *   forget to update it when calling it within a loop).
+         */
+        void nearest_facet_with_hint(
+            const vec3& p,
+            index_t& nearest_facet, vec3& nearest_point, double& sq_dist
+        ) const {
+            if(nearest_facet == NO_FACET) {
+                get_nearest_facet_hint(
+                    p, nearest_facet, nearest_point, sq_dist
+                );
+            }
+            nearest_facet_recursive(
+                p,
+                nearest_facet, nearest_point, sq_dist,
+                1, 0, mesh_.facets.nb()
+            );
+        }
+
+        /*
+         * Finds the nearest facet on the surface, but stops early if a
+         * point within a given distance is found.
+         */
+        index_t facet_in_envelope(
+            const vec3& p, double sq_epsilon, vec3& nearest_point, double& sq_dist
+        ) const {
+            index_t nearest_facet;
+            get_nearest_facet_hint(p, nearest_facet, nearest_point, sq_dist);
+            facet_in_envelope_recursive(
+                p, sq_epsilon,
+                nearest_facet, nearest_point, sq_dist,
+                1, 0, mesh_.facets.nb()
+            );
+            return nearest_facet;
+        }
+
+        /*
+         * Same as before, but stops as soon as a point on the surface in
+         * within a given distance bound from the triangle mesh.
+         */
+        void facet_in_envelope_with_hint(
+            const vec3& p, double sq_epsilon,
+            index_t& nearest_facet, vec3& nearest_point, double& sq_dist
+        ) const {
+            if(nearest_facet == NO_FACET) {
+                get_nearest_facet_hint(
+                    p, nearest_facet, nearest_point, sq_dist
+                );
+            }
+            facet_in_envelope_recursive(
+                p, sq_epsilon,
+                nearest_facet, nearest_point, sq_dist,
+                1, 0, mesh_.facets.nb()
+            );
+        }
+
+        /**
+         * \brief Computes the distance between an arbitrary 3d query
+         *  point and the surface.
+         * \param[in] p query point
+         * \return the squared distance between \p p and the surface.
+         */
+        double squared_distance(const vec3& p) const {
+            vec3 nearest_point;
+            double result;
+            nearest_facet(p, nearest_point, result);
+            return result;
+        }
+
+	/**
+	 * \brief Tests whether this surface mesh has an intersection
+	 *  with a segment.
+	 * \param[in] q1 , q2 the two extremities of the segment.
+	 * \retval true if there exists an intersection between [q1 , q2]
+	 *  and a facet of the mesh.
+	 * \retval false otherwise.
+	 */
+	bool segment_intersection(const vec3& q1, const vec3& q2) const;
+
+    protected:
+
+
+        /**
+         * \brief Computes all the facets that have a bbox that
+         *  intersects a given bbox in a sub-tree of the AABB tree.
+         *
+         * Note that the tree structure is completely implicit,
+         *  therefore the bounds of the (continuous) facet indices
+         *  sequences that correspond to the facets contained
+         *  in the two nodes are sent as well as the node indices.
+         *
+         * \param[in] action ACTION::operator(index_t) is
+         *  invoked for all facet that has a bounding box that
+         *  overlaps \p box.
+         * \param[in] node index of the first node of the AABB tree
+         * \param[in] b index of the first facet in \p node
+         * \param[in] e one position past the index of the last
+         *  facet in \p node
+         */
+        template <class ACTION>
+        void bbox_intersect_recursive(
+            ACTION& action,
+            const Box& box,
+            index_t node, index_t b, index_t e
+        ) const {
+            geo_debug_assert(e != b);
+
+            // Prune sub-tree that does not have intersection
+            if(!bboxes_overlap(box, bboxes_[node])) {
+                return;
+            }
+
+            // Leaf case
+            if(e == b+1) {
+                action(b);
+                return;
+            }
+
+            // Recursion
+            index_t m = b + (e - b) / 2;
+            index_t node_l = 2 * node;
+            index_t node_r = 2 * node + 1;
+
+            bbox_intersect_recursive(action, box, node_l, b, m);
+            bbox_intersect_recursive(action, box, node_r, m, e);
+        }
+
+        /**
+         * \brief Computes all the pairs of intersecting facets
+         *  for two sub-trees of the AABB tree.
+         *
+         * Note that the tree structure is completely implicit,
+         *  therefore the bounds of the (continuous) facet indices
+         *  sequences that correspond to the facets contained
+         *  in the two nodes are sent as well as the node indices.
+         *
+         * \param[in] action ACTION::operator(index_t,index_t) is
+         *  invoked of all pairs of facets that have overlapping
+         *  bounding boxes.
+         * \param[in] node1 index of the first node of the AABB tree
+         * \param[in] b1 index of the first facet in \p node1
+         * \param[in] e1 one position past the index of the last
+         *  facet in \p node1
+         * \param[in] node2 index of the second node of the AABB tree
+         * \param[in] b2 index of the first facet in \p node2
+         * \param[in] e2 one position past the index of the second
+         *  facet in \p node2
+         */
+        template <class ACTION>
+        void intersect_recursive(
+            ACTION& action,
+            index_t node1, index_t b1, index_t e1,
+            index_t node2, index_t b2, index_t e2
+        ) const {
+            geo_debug_assert(e1 != b1);
+            geo_debug_assert(e2 != b2);
+
+            // Since we are intersecting the AABBTree with *itself*,
+            // we can prune half of the cases by skipping the test
+            // whenever node2's facet index interval is greated than
+            // node1's facet index interval.
+            if(e2 <= b1) {
+                return;
+            }
+
+            // The acceleration is here:
+            if(!bboxes_overlap(bboxes_[node1], bboxes_[node2])) {
+                return;
+            }
+
+            // Simple case: leaf - leaf intersection.
+            if(b1 + 1 == e1 && b2 + 1 == e2) {
+                action(b1, b2);
+                return;
+            }
+
+            // If node2 has more facets than node1, then
+            //   intersect node2's two children with node1
+            // else
+            //   intersect node1's two children with node2
+            if(e2 - b2 > e1 - b1) {
+                index_t m2 = b2 + (e2 - b2) / 2;
+                index_t node2_l = 2 * node2;
+                index_t node2_r = 2 * node2 + 1;
+                intersect_recursive(action, node1, b1, e1, node2_l, b2, m2);
+                intersect_recursive(action, node1, b1, e1, node2_r, m2, e2);
+            } else {
+                index_t m1 = b1 + (e1 - b1) / 2;
+                index_t node1_l = 2 * node1;
+                index_t node1_r = 2 * node1 + 1;
+                intersect_recursive(action, node1_l, b1, m1, node2, b2, e2);
+                intersect_recursive(action, node1_r, m1, e1, node2, b2, e2);
+            }
+        }
+
+        /**
+         * \brief Computes a reasonable initialization for
+         *  nearest facet search.
+         *
+         * \details A good initialization makes the algorithm faster,
+         *  by allowing early pruning of subtrees that provably
+         *  do not contain the nearest neighbor.
+         *
+         * \param[in] p query point
+         * \param[out] nearest_facet a facet reasonably near p
+         * \param[out] nearest_point a point in nearest_facet
+         * \param[out] sq_dist squared distance between p and nearest_point
+         */
+        void get_nearest_facet_hint(
+            const vec3& p,
+            index_t& nearest_facet, vec3& nearest_point, double& sq_dist
+        ) const;
+
+        /**
+         * \brief The recursive function used by the implementation
+         *  of nearest_facet().
+         *
+         * \details The first call may use get_nearest_facet_hint()
+         * to initialize nearest_facet, nearest_point and sq_dist,
+         * as done in nearest_facet().
+         *
+         * \param[in] p query point
+         * \param[in,out] nearest_facet the nearest facet so far,
+         * \param[in,out] nearest_point a point in nearest_facet
+         * \param[in,out] sq_dist squared distance between p and nearest_point
+         * \param[in] n index of the current node in the AABB tree
+         * \param[in] b index of the first facet in the subtree under node \p n
+         * \param[in] e one position past the index of the last facet in the
+         *  subtree under node \p n
+         */
+        void nearest_facet_recursive(
+            const vec3& p,
+            index_t& nearest_facet, vec3& nearest_point, double& sq_dist,
+            index_t n, index_t b, index_t e
+        ) const;
+
+        /*
+         * Same as before, but stops early if a point within a given distance
+         * is found.
+         */
+        void facet_in_envelope_recursive(
+            const vec3& p, double sq_epsilon,
+            index_t& nearest_facet, vec3& nearest_point, double& sq_dist,
+            index_t n, index_t b, index_t e
+        ) const;
+
+        /**
+         * \brief The recursive function used by the implementation
+         *  of segment_intersection()
+	 * \param[in] q1 , q2 the segment
+         * \param[in] n index of the current node in the AABB tree
+         * \param[in] b index of the first facet in the subtree under node \p n
+         * \param[in] e one position past the index of the last facet in the
+         *  subtree under node \p n
+	 */
+	bool segment_intersection_recursive(
+	    const vec3& q1, const vec3& q2, index_t n, index_t b, index_t e
+	) const;
+
+    protected:
+        vector<Box> bboxes_;
+        Mesh& mesh_;
+    };
+
+}


### PR DESCRIPTION
- Switch to thread-local static for ISPC vectors, and use `std::vector` to avoid deallocating unnecessarily.
- Switch to `std::array<>` instead of `std::vector` for individual tet coordinates before passing it to the energy functions (avoids heap allocation)
- Big performance gain in the distance queries with AABB trees:
  - Stops AABB tree traversal once a point at distance < eps is found.
  - For each sample in a triangle, compute the distance to the previously returned facet and avoid calling the AABB tree if it is already < eps (*big* perf improvement)
- Split main pipeline into subfunctions, to make it easier to replace/tweak different steps.

Now the bottleneck doesn't seem to be in the distance queries anymore (I don't think multithreading this part would help much). Rather, it looks like the heap allocations and the use of `std::unordered_set<>` in the local operations (edge collapse/etc.) are the new bottleneck.