### PR TITLE
Fixing libigl static build

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -12,6 +12,7 @@
 #include <tetwild/MeshRefinement.h>
 #include <igl/read_triangle_mesh.h>
 #include <igl/write_triangle_mesh.h>
+#include <igl/writeOBJ.h>
 #include <pymesh/MshSaver.h>
 #include <tetwild/DisableWarnings.h>
 #include <CLI/CLI.hpp>

--- a/src/tetwild/Preprocess.cpp
+++ b/src/tetwild/Preprocess.cpp
@@ -22,6 +22,7 @@
 #include <igl/unique.h>
 #include <igl/unique_simplices.h>
 #include <igl/bounding_box_diagonal.h>
+#include <igl/writeSTL.h>
 #include <geogram/mesh/mesh_reorder.h>
 #include <geogram/mesh/mesh_geometry.h>
 #include <geogram/mesh/mesh_repair.h>


### PR DESCRIPTION
Adding two include statements that allows for building with option ```option(LIBIGL_USE_STATIC_LIBRARY     "Use libigl as static library" ON)```