### PR TITLE
Implement absolute edge length

### DIFF
--- a/include/tetwild/Args.h
+++ b/include/tetwild/Args.h
@@ -20,6 +20,25 @@ struct Args {
     // Initial target edge-length at every vertex (in % of the bbox diagonal)
     double initial_edge_len_rel = 1/20.0;
 
+    // Initial absolute target edge-length at every vertex. Only used if -a is specified.
+    double initial_edge_len_abs = 0.0;
+
+    // convenience function to get the correct absolute edge length depending
+    // on what was set by the CLI reader
+    double getAbsoluteEdgeLength(const double bbox_diag) const
+    {
+        return initial_edge_len_abs != 0.0 ? initial_edge_len_abs
+          : initial_edge_len_rel*bbox_diag;
+    }
+
+    // convenience function to get the correct relative edge length depending
+    // on what was set by the CLI reader
+    double getRelativeEdgeLength(const double bbox_diag) const
+    {
+        return initial_edge_len_abs != 0.0 ? initial_edge_len_abs/bbox_diag
+          : initial_edge_len_rel;
+    }
+
     // Target epsilon (in % of the bbox diagonal)
     double eps_rel = 1e-3;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -100,7 +100,9 @@ int main(int argc, char *argv[]) {
     app.add_option("input,--input", input_surface, "Input surface mesh INPUT in .off/.obj/.stl/.ply format. (string, required)")->required();
     app.add_option("output,--output", output_volume, "Output tetmesh OUTPUT in .msh format. (string, optional, default: input_file+postfix+'.msh')");
     app.add_option("--postfix", args.postfix, "Postfix P for output files. (string, optional, default: '_')");
-    app.add_option("-l,--ideal-edge-length", args.initial_edge_len_rel, "ideal_edge_length = diag_of_bbox * L. (double, optional, default: 0.05)");
+    auto absolute = app.add_option("-a,--ideal-absolute-edge-length", args.initial_edge_len_abs, "Absolute edge length (not scaled by bbox). -a and -l cannot both be given as arguments.");
+    auto relative = app.add_option("-l,--ideal-edge-length", args.initial_edge_len_rel, "ideal_edge_length = diag_of_bbox * L. (double, optional, default: 0.05)");
+    relative->excludes(absolute);
     app.add_option("-e,--epsilon", args.eps_rel, "epsilon = diag_of_bbox * EPS. (double, optional, default: 1e-3)");
     app.add_option("--stage", args.stage, "Run pipeline in stage STAGE. (integer, optional, default: 1)");
     app.add_option("--filter-energy", args.filter_energy_thres, "Stop mesh improvement when the maximum energy is smaller than ENERGY. (double, optional, default: 10)");

--- a/src/tetwild/DelaunayTetrahedralization.cpp
+++ b/src/tetwild/DelaunayTetrahedralization.cpp
@@ -64,10 +64,10 @@ void DelaunayTetrahedralization::getVoxelPoints(const Point_3& p_min, const Poin
     GEO::MeshFacetsAABB geo_face_tree(geo_surface_mesh);
 
     double voxel_resolution;
-    if(args.initial_edge_len_rel < 5.0) {
+    if(args.getRelativeEdgeLength(state.bbox_diag) < 5.0) {
         voxel_resolution = state.bbox_diag / 20.0;
     } else {
-        voxel_resolution = state.bbox_diag * args.initial_edge_len_rel;
+        voxel_resolution = args.getAbsoluteEdgeLength(state.bbox_diag);
     }
     std::array<double, 3> d;
     std::array<int, 3> N;

--- a/src/tetwild/State.cpp
+++ b/src/tetwild/State.cpp
@@ -23,7 +23,7 @@ State::State(const Args &args, const Eigen::MatrixXd &V)
     , bbox_diag(igl::bounding_box_diagonal(V))
     , eps_input(bbox_diag * args.eps_rel)
     , eps_delta(args.sampling_dist_rel > 0 ? 0 : eps_input / args.stage / std::sqrt(3))
-    , initial_edge_len(bbox_diag * args.initial_edge_len_rel)
+    , initial_edge_len(args.getAbsoluteEdgeLength(bbox_diag))
 {
     if (args.sampling_dist_rel > 0) {
         //for testing only


### PR DESCRIPTION
Hello!

For some applications we have in our group it is much easier to specify the absolute edge length instead of a relative one - I added a new command line flag for it and some convenience functions for returning the absolute or relative edge length to `Args`.